### PR TITLE
Add title to display when no reminders are passed

### DIFF
--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -1,10 +1,13 @@
 <h1>Raphael</h1>
-
-{{#each model as |reminder|}}
-  <div>
-    {{#link-to "reminders.reminder" reminder class='reminder-item'}}{{reminder.title}}{{/link-to}}
-  </div>
-{{/each}}
+{{#if model}}
+  {{#each model as |reminder|}}
+    <div>
+      {{#link-to "reminders.reminder" reminder class='reminder-item'}}{{reminder.title}}{{/link-to}}
+    </div>
+  {{/each}}
+  {{else}}
+  <h1 class="no-reminder-msg">No Reminders to Display</h1>
+{{/if}}
 
 {{#link-to "reminders.new" class='new-button'}}<button>Create New</button>{{/link-to}}
 

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -5,7 +5,7 @@
       {{#link-to "reminders.reminder" reminder class='reminder-item'}}{{reminder.title}}{{/link-to}}
     </div>
   {{/each}}
-  {{else}}
+{{else}}
   <h1 class="no-reminder-msg">No Reminders to Display</h1>
 {{/if}}
 

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -35,17 +35,28 @@ test('add new reminder to the page', function(assert) {
 
   visit('/reminders');
   andThen(function() {
-    assert.equal(Ember.$('.reminder-item').length, 5)
+    assert.equal(Ember.$('.reminder-item').length, 5);
   });
   click('.new-button');
 
-  fillIn('.title-input', 'This is a title')
-  fillIn('.reminder-input', 'This is a reminder')
+  fillIn('.title-input', 'This is a title');
+  fillIn('.reminder-input', 'This is a reminder');
 
-  click('.submit-btn')
+  click('.submit-btn');
 
   andThen(function() {
-    assert.equal(Ember.$('.reminder-item').length, 6)
-    assert.equal(Ember.$('.reminder-item:last').text(), 'This is a title')
+    assert.equal(Ember.$('.reminder-item').length, 6);
+    assert.equal(Ember.$('.reminder-item:last').text(), 'This is a title');
+  });
+});
+
+test('display No reminders header when no reminders are passed', function(assert) {
+  server.createList('reminder', 0);
+
+  visit('/reminders');
+
+  andThen(function() {
+    assert.equal(Ember.$('.reminder-item').length, 0);
+    assert.equal(Ember.$('.no-reminder-msg').text(), 'No Reminders to Display');
   });
 });


### PR DESCRIPTION
Add test to check if title of no reminders is shown

## Purpose

To display a header warning when no reminders are within the database

close #5 

## Approach

Added conditional to check if reminders existed that rendered different elements to the DOM 

### Learning

Ember conditionals

[Handlebar conditional docs](http://handlebarsjs.com/builtin_helpers.html)
[Ember conditional docs](https://guides.emberjs.com/v2.12.0/templates/conditionals/#toc-toggle)

### Test coverage 

Pass and empty reminders array and prove that warning message is rendered on DOM

### Follow-up tasks

issue #6 

### Screenshots

#### After

![](http://recordit.co/MyYky7fg8f.gif)